### PR TITLE
Set EMBEDDED_CONTENT_CONTAINS_SWIFT to NO

### DIFF
--- a/Cosmos.xcodeproj/project.pbxproj
+++ b/Cosmos.xcodeproj/project.pbxproj
@@ -798,7 +798,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = "Cosmos-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -818,7 +817,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
 				INFOPLIST_FILE = "Cosmos-tvOS/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";


### PR DESCRIPTION
Setting this to `YES` leads to Swift standard library being embedded in `Cosmos.framework`.
There is no need to do this as Swift standard library are provided by containing app (the app that uses Cosmos library).
If any framework contains Swift Standard Library, an error is raised while trying to submit to iTunes Connect.
`ITMS-90206: "Invalid Bundle. The bundle at 'Livingroom.app/Frameworks/Cosmos.framework' contains disallowed file 'Frameworks'."`