### PR TITLE
Changed access level of CosmosView from public to open

### DIFF
--- a/Cosmos/CosmosView.swift
+++ b/Cosmos/CosmosView.swift
@@ -12,7 +12,7 @@ Example:
 Shows: ★★★★☆ (132)
 
 */
-@IBDesignable public class CosmosView: UIView {
+@IBDesignable open class CosmosView: UIView {
     
   /**
   
@@ -47,7 +47,7 @@ Shows: ★★★★☆ (132)
   private var viewSize = CGSize()
 
   /// Draws the stars when the view comes out of storyboard with default settings
-  public override func awakeFromNib() {
+  open override func awakeFromNib() {
     super.awakeFromNib()
     
     update()
@@ -162,7 +162,7 @@ Shows: ★★★★☆ (132)
   }
   
   /// Returns the content size to fit all the star and text layers.
-  override public var intrinsicContentSize:CGSize {
+  override open var intrinsicContentSize:CGSize {
     return viewSize
   }
   
@@ -173,7 +173,7 @@ Shows: ★★★★☆ (132)
   }
   
   /// Called by the system in accessibility voice-over mode when the value is incremented by the user.
-  public override func accessibilityIncrement() {
+  open override func accessibilityIncrement() {
     super.accessibilityIncrement()
     
     rating += CosmosAccessibility.accessibilityIncrement(rating, settings: settings)
@@ -182,7 +182,7 @@ Shows: ★★★★☆ (132)
   }
   
   /// Called by the system in accessibility voice-over mode when the value is decremented by the user.
-  public override func accessibilityDecrement() {
+  open override func accessibilityDecrement() {
     super.accessibilityDecrement()
     
     rating -= CosmosAccessibility.accessibilityDecrement(rating, settings: settings)
@@ -199,7 +199,7 @@ Shows: ★★★★☆ (132)
   public var didFinishTouchingCosmos: ((Double)->())?
   
   /// Overriding the function to detect the first touch gesture.
-  public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+  open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
     super.touchesBegan(touches, with: event)
     
     if let touch = touches.first {
@@ -209,7 +209,7 @@ Shows: ★★★★☆ (132)
   }
   
   /// Overriding the function to detect touch move.
-  public override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+  open override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
     super.touchesMoved(touches, with: event)
     
     if let touch = touches.first {
@@ -219,7 +219,7 @@ Shows: ★★★★☆ (132)
   }
   
   /// Detecting event when the user lifts their finger.
-  public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+  open override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
     super.touchesEnded(touches, with: event)
     
     didFinishTouchingCosmos?(rating)
@@ -265,7 +265,7 @@ Shows: ★★★★☆ (132)
   }
   
   /// Increase the hitsize of the view if it's less than 44px for easier touching.
-  override public func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+  override open func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
     let oprimizedBounds = CosmosTouchTarget.optimize(bounds)
     return oprimizedBounds.contains(point)
   }
@@ -364,7 +364,7 @@ Shows: ★★★★☆ (132)
   }
   
   /// Draw the stars in interface buidler
-  public override func prepareForInterfaceBuilder() {
+  open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
     
     update()

--- a/Distrib/CosmosDistrib.swift
+++ b/Distrib/CosmosDistrib.swift
@@ -836,7 +836,7 @@ Example:
 Shows: ★★★★☆ (132)
 
 */
-@IBDesignable public class CosmosView: UIView {
+@IBDesignable open class CosmosView: UIView {
     
   /**
   
@@ -871,7 +871,7 @@ Shows: ★★★★☆ (132)
   private var viewSize = CGSize()
 
   /// Draws the stars when the view comes out of storyboard with default settings
-  public override func awakeFromNib() {
+  open override func awakeFromNib() {
     super.awakeFromNib()
     
     update()
@@ -986,7 +986,7 @@ Shows: ★★★★☆ (132)
   }
   
   /// Returns the content size to fit all the star and text layers.
-  override public var intrinsicContentSize:CGSize {
+  override open var intrinsicContentSize:CGSize {
     return viewSize
   }
   
@@ -997,7 +997,7 @@ Shows: ★★★★☆ (132)
   }
   
   /// Called by the system in accessibility voice-over mode when the value is incremented by the user.
-  public override func accessibilityIncrement() {
+  open override func accessibilityIncrement() {
     super.accessibilityIncrement()
     
     rating += CosmosAccessibility.accessibilityIncrement(rating, settings: settings)
@@ -1006,7 +1006,7 @@ Shows: ★★★★☆ (132)
   }
   
   /// Called by the system in accessibility voice-over mode when the value is decremented by the user.
-  public override func accessibilityDecrement() {
+  open override func accessibilityDecrement() {
     super.accessibilityDecrement()
     
     rating -= CosmosAccessibility.accessibilityDecrement(rating, settings: settings)
@@ -1023,7 +1023,7 @@ Shows: ★★★★☆ (132)
   public var didFinishTouchingCosmos: ((Double)->())?
   
   /// Overriding the function to detect the first touch gesture.
-  public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+  open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
     super.touchesBegan(touches, with: event)
     
     if let touch = touches.first {
@@ -1033,7 +1033,7 @@ Shows: ★★★★☆ (132)
   }
   
   /// Overriding the function to detect touch move.
-  public override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+  open override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
     super.touchesMoved(touches, with: event)
     
     if let touch = touches.first {
@@ -1043,7 +1043,7 @@ Shows: ★★★★☆ (132)
   }
   
   /// Detecting event when the user lifts their finger.
-  public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+  open override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
     super.touchesEnded(touches, with: event)
     
     didFinishTouchingCosmos?(rating)
@@ -1089,7 +1089,7 @@ Shows: ★★★★☆ (132)
   }
   
   /// Increase the hitsize of the view if it's less than 44px for easier touching.
-  override public func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+  override open func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
     let oprimizedBounds = CosmosTouchTarget.optimize(bounds)
     return oprimizedBounds.contains(point)
   }
@@ -1188,7 +1188,7 @@ Shows: ★★★★☆ (132)
   }
   
   /// Draw the stars in interface buidler
-  public override func prepareForInterfaceBuilder() {
+  open override func prepareForInterfaceBuilder() {
     super.prepareForInterfaceBuilder()
     
     update()


### PR DESCRIPTION
Under Swift 3, an access level of `open` is required in order to be able to create a subclass outside of the class' defining module.