### PR TITLE
Adjusting documentation comment

### DIFF
--- a/Distrib/CosmosDistrib.swift
+++ b/Distrib/CosmosDistrib.swift
@@ -884,7 +884,7 @@ Example:
     cosmosView.rating = 4
     cosmosView.text = "(123)"
 
-Shows: ★★★★☆ (132)
+Shows: ★★★★☆ (123)
 
 */
 @IBDesignable open class CosmosView: UIView {


### PR DESCRIPTION
The comment showing an example of using the property `text` and its output was incorrect.

 Example:
 ```
 cosmosView.rating = 4
 cosmosView.text = "(123)"
 ```
 Shows: ★★★★☆ (132)

Adjusted to:
 Shows: ★★★★☆ (**123**)